### PR TITLE
Programming Event Information & Signup, Hide Old Event

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+travisspark.org

--- a/_data/contact.yml
+++ b/_data/contact.yml
@@ -53,3 +53,10 @@ user-message:
   id: user-message
   text: Message
   name: entry.839337160
+
+event-interest:
+  id: event-interest
+  text: I'm interested in the 26 Oct Programming Event (Military Only)
+  legend: Events
+  name: entry.212837715
+  value: Interested

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -39,11 +39,21 @@
    text_date: 'March 18-22, 2019'
    start_date: 2019-03-18
 
+ - title: Phoenix Spark Programming Event
+   location: Innovation Lab
+   desc: 
+     Phoenix Spark is hosting an event for Airmen to demonstrate and develop their coding capabilities. This is an opporunity to network, build diverse teams,
+     and learn together. Participants will choose from a set of problems and build solutions in Python, Swift, Java, HTML/CSS/Javascript, and Powershell.
+   event_url: https://travisspark.org/contact
+   section: Conferences ## Sections: Courses, Conferences, Weekly Meeting
+   text_date: 3:00 pm 26th Oct, 2018 ## <string> For Display
+   start_date: 2018-10-26 ## <YYYY-MM-DD For Sorting
+
  - title: Air Force Additive Manufacturing Technical Interchange Meeting (AFAMTIM)
    location: Dayton, OH
    desc: AFAMTIM is the premier USAF Additive Manufacturing (AM) showcase offering technology demonstrations, collaborative learning opportunities, USAF AM polymer operator qualification, and insight into future technologies around AM to ultimately accelerate the technical transition and adoption of AM within the USAF.
    event_url: http://www.afcpo.com/additivemanufacturing.html
-   section: Conferences
+   section: # Conferences
    text_date: 'Sep 26-28, 2018' #For Display
    start_date: 2018-09-26 #For Sorting
 

--- a/_data/events.yml
+++ b/_data/events.yml
@@ -6,13 +6,21 @@
   #  section: ## Sections: Courses, Conferences, Weekly Meeting
   #  text_date: ## <string> For Display
   #  start_date:  ## <YYYY-MM-DD For Sorting
+
+ - title: STEAM Library Activities
+   location: Mitchell Memorial Library, 510 Travis Ave Travis AFB, CA 94535
+   desc: Activities for students to learn about Science, Technology, Engineering, Art, and Mathematics (STEAM). Past events include designing and building a toy roller coaster to learn about physics. Children 8 years and under must be accompanied by an adult.
+   event_url: http://www.mitchellmemoriallibrary.org/
+   section: Weekly Meeting ## Sections: Courses, Conferences, Weekly Meeting
+   text_date: 3:00-5:00 pm, Wednesdays ## <string> For Display
+   start_date: 1900-01-02 ## <YYYY-MM-DD For Sorting
  
  - title: Phoenix Spark Working Lunch
    location: Phoenix Spark Lab Building 241 Travis AFB, CA
    desc: An open space for current and potential participants to update ongoing projects and pitch ideas.
    event_url: https://www.travisspark.org
    section: Weekly Meeting 
-   text_date: 1200, Every Friday ## <string> For Display
+   text_date: 12:00 pm, Fridays ## <string> For Display
    start_date: 1900-01-01 ## <YYYY-MM-DD For Sorting
 
  - title: The Air Force Information Technology & Cyberpower (AFITC) Conference 
@@ -28,7 +36,7 @@
    desc: GTC is the premier AI and deep learning conference series, providing you with training, insights, and direct access to experts from NVIDIA and other leading organizations.
    event_url: https://www.nvidia.com/en-us/gtc-dc/
    section: Conferences
-   text_date: 'March 18-22, 2018'
+   text_date: 'March 18-22, 2019'
    start_date: 2019-03-18
 
  - title: Air Force Additive Manufacturing Technical Interchange Meeting (AFAMTIM)

--- a/_pages/contact.md
+++ b/_pages/contact.md
@@ -57,6 +57,13 @@ sidenav: contact
         {% endfor %}
         </ul>
     </fieldset>
+    <!-- Input: 26 Oct Programming event -->
+    <fieldset class="usa-fieldset-inputs usa-sans">
+        <label for="{{ contact_data.event-interest.id }}">{{ contact_data.event-interest.legend }}</label>
+        <legend class="usa-sr-only">{{ contact_data.event-interest.legend }}</legend>
+            <input id ="{{ contact_data.event-interest.value | slugify }}" type="checkbox" name="{{ contact_data.event-interest.name }}" value="{{ contact_data.event-interest.value }}">
+            <label for="{{ contact_data.event-interest.value | slugify }}">{{ contact_data.event-interest.text }}</label>
+    </fieldset>
     <!-- Input: User Message -->
     <label for="{{ contact_data.user-message.id }}">{{ contact_data.user-message.text }}</label>
     <textarea id="{{ contact_data.user-message.id }}" name="{{ contact_data.user-message.name }}"></textarea>


### PR DESCRIPTION
### Checklist
 - [x] Created clear and concise name
 - [ ] Focused on one issue
 - [x] Passed Travis checks
 - [x] Referenced issue number and title
 - [x] Described implementation/solution
 - [ ] Asked for review
   - spark-website team
   - appropriate contributor

### Issue:
 - Number: #65, Programming Event
 - Title: Hide AFAMTIM Event, Programming Event

### Implementation/Solution
1. Changed Base Google Form
2. Changed spark-website form to include checkbox to signup for Programming Event
3. Added Programming Event information to events page
4. Hid AFAMTIM Event

[Preview Page](https://tangoyankee.github.io/spark-website/)


