### PR TITLE
change quotes surrounding news description

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -26,7 +26,7 @@
   author: Capt Ryan McGuire and Capt Lyndsey Horn
   org: 60th Air Mobility Wing Public Affairs
   date: 2019-02-05 #YYYY-MM-DD
-  desc: 'Spark started as a group of motivated, and admittedly frustrated, individuals.  Frustrated with the small nuisances that plagued their day-to-day work life, and how seemingly simple solutions were right outside the gate but just out of reach.  Airmen felt frustrated because a simple change was always met with a 'no' or a 'yes, but insert long list of illogical barriers here.'
+  desc: Spark started as a group of motivated, and admittedly frustrated, individuals.  Frustrated with the small nuisances that plagued their day-to-day work life, and how seemingly simple solutions were right outside the gate but just out of reach.  Airmen felt frustrated because a simple change was always met with a 'no' or a 'yes, but insert long list of illogical barriers here.
   press_link: https://www.travis.af.mil/News/Commentaries/Display/Article/1748844/unleashing-the-innovative-spirit-of-airmen/
   section: Collaboration
 


### PR DESCRIPTION
### Checklist
 - [x] Created clear and concise name
 - [x] Focused on one issue
 - [ ] Passed Travis checks
 - [ ] Referenced issue number and title
 - [ ] Described implementation/solution
 - [ ] Asked for review
   - spark-website team
   - appropriate contributor

### Issue:
 - Number:
 - Title:

### Implementation/Solution
There are internal quotes in the description of the article. Consequently, a different version of the quotes need to be used to surround the description. Otherwise, they will incorrectly close early, once hitting the internal quote.

